### PR TITLE
Add switch to convert partial ambiguities into `N`

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -10,7 +10,7 @@
 
 TwoBit.jl provides I/O and utilities for manipulating 2Bit sequence data files.
 
-2Bit is a binary file format designed for storing a genome consists of multiple chromosomal sequences.
+2Bit is a binary file format (described [here](https://genome.ucsc.edu/FAQ/FAQformat.html#format7)) designed for storing a genome that consists of multiple chromosomal sequences.
 
 The reading speed is often an order of magnitude faster than that of FASTA and the file size is smaller.
 


### PR DESCRIPTION
# Add switch to convert partial ambiguities into `N`

## Types of changes

This PR implements the following changes:
_(Please tick any or all of the following that are applicable)_

* [x] :sparkles: New feature (A non-breaking change which adds functionality).
* [ ] :bug: Bug fix (A non-breaking change, which fixes an issue).
* [ ] :boom: Breaking change (fix or feature that would cause existing functionality to change).

## :clipboard: Additional detail

Allows partial ambiguities to be written as `N`s with opt-in switch as a kwarg to the `write` method.

Wild input genomes, including human reference genomes, have scattered partial ambiguities. Trying to first sanitize the sequence complexifies the code. It's quite simple to allow the TwoBit writer to convert these bases into `N`s and take care of both problems at once.

## :ballot_box_with_check: Checklist

- [x] :art: The changes implemented is consistent with the [julia style guide](https://docs.julialang.org/en/stable/manual/style-guide/).
- [x] :blue_book: I have updated and added relevant docstrings, in a manner consistent with the [documentation styleguide](https://docs.julialang.org/en/stable/manual/documentation/).
- [x] :blue_book: I have added or updated relevant user and developer manuals/documentation in `docs/src/`.
- [ ] :ok: There are unit tests that cover the code changes I have made.
- [ ] :ok: The unit tests cover my code changes AND they pass.
- [ ] :pencil: I have added an entry to the `[UNRELEASED]` section of the manually curated `CHANGELOG.md` file for this repository.
- [x] :ok: All changes should be compatible with the latest stable version of Julia.
- [x] :thought_balloon: I have commented liberally for any complex pieces of internal code.
